### PR TITLE
Updated to webpack 4

### DIFF
--- a/spec/fixtures/expected.html
+++ b/spec/fixtures/expected.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Webpack App</title>
-  <link rel="preload" href="bundle.js" as="script"><link rel="prefetch" href="bundle.js"></head>
+  <link rel="preload" href="main.js" as="script"><link rel="prefetch" href="main.js"></head>
   <body>
-  <script type="text/javascript" src="bundle.js"></script></body>
+  <script type="text/javascript" src="main.js"></script></body>
 </html>

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -12,9 +12,12 @@ describe('HtmlResourceHintPlugin', function () {
   it('adds prefetch tags by default', function (done) {
     var expected = fs.readFileSync(path.resolve(__dirname, 'fixtures/expected.html')).toString();
     var compiler = webpack({
-      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      entry: {
+        main: path.join(__dirname, 'fixtures', 'entry.js')
+      },
       output: {
-        path: OUTPUT_DIR
+        path: OUTPUT_DIR,
+        filename: '[name].js'
       },
       plugins: [
         new HtmlWebpackPlugin(),
@@ -35,9 +38,12 @@ describe('HtmlResourceHintPlugin', function () {
   it('adds prefetch tags', function (done) {
     var expected = fs.readFileSync(path.resolve(__dirname, 'fixtures/expected.html')).toString();
     var compiler = webpack({
-      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      entry: {
+        main: path.join(__dirname, 'fixtures', 'entry.js')
+      },
       output: {
-        path: OUTPUT_DIR
+        path: OUTPUT_DIR,
+        filename: '[name].js'
       },
       plugins: [
         new HtmlWebpackPlugin({
@@ -60,9 +66,12 @@ describe('HtmlResourceHintPlugin', function () {
 describe('HtmlResourceHintPlugin', function () {
   it('adds no file which do not match the filter', function (done) {
     var compiler = webpack({
-      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      entry: {
+        main: path.join(__dirname, 'fixtures', 'entry.js')
+      },
       output: {
-        path: OUTPUT_DIR
+        path: OUTPUT_DIR,
+        filename: '[name].js'
       },
       plugins: [
         new HtmlWebpackPlugin({
@@ -86,9 +95,12 @@ describe('HtmlResourceHintPlugin', function () {
 describe('HtmlResourceHintPlugin', function () {
   it('allows to add fixed prefetch url', function (done) {
     var compiler = webpack({
-      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      entry: {
+        main: path.join(__dirname, 'fixtures', 'entry.js')
+      },
       output: {
-        path: OUTPUT_DIR
+        path: OUTPUT_DIR,
+        filename: '[name].js'
       },
       plugins: [
         new HtmlWebpackPlugin({
@@ -110,9 +122,12 @@ describe('HtmlResourceHintPlugin', function () {
 describe('HtmlResourceHintPlugin', function () {
   it('allows to add fixed preload url', function (done) {
     var compiler = webpack({
-      entry: path.join(__dirname, 'fixtures', 'entry.js'),
+      entry: {
+        main: path.join(__dirname, 'fixtures', 'entry.js')
+      },
       output: {
-        path: OUTPUT_DIR
+        path: OUTPUT_DIR,
+        filename: '[name].js'
       },
       plugins: [
         new HtmlWebpackPlugin({


### PR DESCRIPTION
I had to put named entries to enforce compatibility to older versions, on 4 if filename is not provided, they changed default naming from bundle.js to main.js,

If you want to upgrade dependency to get only ^4.1.1, you can remove the else from index.js and revert spec/index.spec.js to original one, keeping the fixture html calling main.js.

Fell free to change anything on code that keeps you more confortable.

And recommend to test too, I've tested here on webpack 4 and 1.15.0 but as I'm still rookie on Github collab on public repos, feeling kinda insecure here.